### PR TITLE
getArea for herbs Fix #95

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: NPSForVeg
 Type: Package
 Title: Data anaylsis and graphing for NPS forest vegetation monitoring.
-Version: 0.2.17
-Date: 2018-03-20
+Version: 0.2.18
+Date: 2018-03-23
 Author: John Paul Schmit, Kate Miller, Liz Matthews
 Maintainer: John Paul Schmit <John_Schmit@nps.gov>
 Description: This package is designed to analyze and display forest monitoring

--- a/R/getArea.R
+++ b/R/getArea.R
@@ -38,7 +38,7 @@ setMethod(f="getArea", signature="NPSForVeg",
                      single=return(object@SapPlotSize[2]),
                      count=return(object@SapPlotSize[1]) 
       ), 
-      seedlings =, herbs = switch (type,
+      seedlings = switch (type,
                         all=return(object@SeedPlotSize[1]*object@SeedPlotSize[2]),
                         single=return(object@SeedPlotSize[2]),
                         count=return(object@SeedPlotSize[1]) 
@@ -46,7 +46,7 @@ setMethod(f="getArea", signature="NPSForVeg",
       shrubs = switch (type,
                          all=return(object@ShrubPlotSize[1]*object@ShrubPlotSize[2]),
                          single=return(object@ShrubPlotSize[2]),
-                         count=return(object@ShrubPlotSize[1]), 
+                         count=return(object@ShrubPlotSize[1]) 
       ),          
       shseedlings = switch (type,
                      all=return(object@ShSeedPlotSize[1]*object@ShSeedPlotSize[2]),


### PR DESCRIPTION
Removed herbs from seedlings area calculation, and deleted extra comma after shrubs area calculation. NETN samples seedlings in microplots and herbs in quadrats, so need to keep area calculations separate. I checked that the herbs and seedlings areas (count, single and all) were correctly calculated for MIDN, so it should work for NCRN too.